### PR TITLE
Add shared repolint workflow

### DIFF
--- a/.github/workflows/repolint.yml
+++ b/.github/workflows/repolint.yml
@@ -1,0 +1,18 @@
+name: Klarna repolint
+
+on:
+  workflow_call:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks-out the repository under $GITHUB_WORKSPACE
+      - uses: actions/checkout@v3
+
+      - name: Use custom rules
+        run: wget https://raw.githubusercontent.com/klarna-incubator/meta/master/repolint.json
+
+      - name: Run repolint
+        run: npx repolinter@0.11.2 $GITHUB_WORKSPACE

--- a/repolint.json
+++ b/repolint.json
@@ -14,14 +14,6 @@
         "error",
         { "files": ["README*"], "nocase": true }
       ],
-      "contributing-file-exists:file-existence": [
-        "error",
-        { "files": [".github/CONTRIBUTING*"] }
-      ],
-      "code-of-conduct-file-exists:file-existence": [
-        "error",
-        { "files": [".github/CODE_OF_CONDUCT*"] }
-      ],
       "changelog-file-exists:file-existence": [
         "error",
         { "files": ["CHANGELOG*"], "nocase": true }


### PR DESCRIPTION
This enables us to maintain a single version of this workflow and just reference this in the template/other repos. I've removed the checks for contributing guide and CoC as I've simply made them default in the [.github repo](https://github.com/klarna-incubator/.github) for the same reason. 