### PR TITLE
Update actions/checkout version to v4

### DIFF
--- a/.github/workflows/repolint.yml
+++ b/.github/workflows/repolint.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Use custom rules
         run: wget https://raw.githubusercontent.com/klarna-incubator/meta/master/repolint.json


### PR DESCRIPTION
Update workflow action to resolve Node.js 16 deprecation warnings.

`Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.`